### PR TITLE
remove platform selection from issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,15 +23,6 @@ body:
     label: Additional context
     description: Add any other context or screenshots about the bug here.
 
-- type: checkboxes
-  id: platforms
-  attributes:
-    label: "Applies to the following platforms:"
-    options:
-    - label: WinUI
-    - label: WPF
-    - label: UWP
-
 - type: textarea
   attributes:
     label: About your setup

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,18 +14,9 @@ body:
 - type: textarea
   attributes:
     label: Describe alternatives you've considered
-    description: A clear and concise description of any alternative solutions or features you've considered. 
+    description: A clear and concise description of any alternative solutions or features you've considered.
 
 - type: textarea
   attributes:
     label: Additional context
     description: Add any other context or screenshots about the feature request here.
-
-- type: checkboxes
-  id: platforms
-  attributes:
-    label: "Applies to the following platforms:"
-    options:
-    - label: WinUI
-    - label: WPF
-    - label: UWP

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,12 +4,6 @@
 
 **Which issue does this PR relate to?**
 
-**Applies to the following platforms:**
-
-- [ ] WinUI
-- [ ] WPF
-- [ ] UWP
-
 **Anything that requires particular review or attention?**
 
 **Do all automated tests pass?**
@@ -22,7 +16,6 @@
 
 **If you've included a new template:**
   - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/TemplateStudio/wiki/Checklist:-Template-Verification).
-  - Be sure it's included in the list on this [UWP](https://github.com/microsoft/TemplateStudio/blob/main/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/TemplateStudio/blob/main/docs/WPF/getting-started-endusers.md) getting started doc.
 
 **Have you raised issues for any needed follow-on work?**
 


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
removes mentioning WinUI, WPF and UWP in issue/PR templates