### PR TITLE
Avoid crashing Visual Studio when template wizard fails

### DIFF
--- a/code/SharedFunctionality.UI/VisualStudio/SolutionWizard.cs
+++ b/code/SharedFunctionality.UI/VisualStudio/SolutionWizard.cs
@@ -104,8 +104,7 @@ namespace Microsoft.Templates.UI.VisualStudio
             }
             catch (System.Exception exc)
             {
-                System.Diagnostics.Debug.WriteLine(exc);
-                System.Diagnostics.Debugger.Break();
+                System.Diagnostics.Debug.WriteLine(exc);                
                 AppHealth.Current.Exception.TrackAsync(exc, Resources.ErrorFailedToGenerateProjectFromTemplates).FireAndForget();
             }
         }
@@ -156,8 +155,6 @@ namespace Microsoft.Templates.UI.VisualStudio
             catch (System.Exception exc)
             {
                 System.Diagnostics.Debug.WriteLine(exc);
-                System.Diagnostics.Debugger.Break();
-
                 throw;
             }
         }


### PR DESCRIPTION
Fixes: #14

These calls to Debugger.Break crash Visual Studio in the wild, and is cause of the #11 crash in 17.6. Remove them.

# PR checklist

**Quick summary of changes**

**Which issue does this PR relate to?**
#14

**Anything that requires particular review or attention?**
N/A

**Do all automated tests pass?**
N/A

**Have automated tests been added for new features?**
N/A

**If you've changed the UI:**
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).
N/A

**If you've included a new template:**
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/TemplateStudio/wiki/Checklist:-Template-Verification).
N/A

**Have you raised issues for any needed follow-on work?**
N/A

**Have docs been updated?**
N/A

**If breaking changes or different ways of doing things have been introduced, have they been communicated widely?**
N/A